### PR TITLE
重制《中国社会科学》样式

### DIFF
--- a/中国社会科学.csl
+++ b/中国社会科学.csl
@@ -1,577 +1,621 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" sort-separator="；" page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize="false" initialize-with=". " page-range-format="expanded" default-locale="en-US">
   <info>
-    <title>中国社会科学  Social Sciences in China (Chinese)</title>
+    <title>中国社会科学</title>
     <id>http://www.zotero.org/styles/social-sciences-in-china</id>
+    <link href="http://www.zotero.org/styles/social-sciences-in-china" rel="self"/>
+    <link href="http://sscp.cssn.cn/tgxt/zgshkxtg/" rel="documentation"/>
     <author>
-      <name> edward zhou</name>
+      <name>Edward Zhou</name>
       <email>edwardzhoujiaxi@gmail.com</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
-    <category field="chinese social science"/>
-    <category field="chinese humanities"/>
-    <summary>根据fanzhen《历史研究》引文规范、pulipuli制作的APA中文格式以及《中国社会科学》引文规范改制，具体用法和特性见说明</summary>
-    <published>2021-02-18</published>
-    <updated>2021-02-18T08:45:31+00:00</updated>
+    <category field="social_science"/>
+    <category field="humanities"/>
+    <updated>2022-11-04T20:06:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>p. </single>
-        <multiple>pp. </multiple>
-      </term>
-      <term name="locator" form="short">
-        <single>p. </single>
-        <multiple>pp. </multiple>
-      </term>
-      <date form="text">
-        <date-part name="month" suffix=" "/>
-        <date-part name="day" suffix=", "/>
-        <date-part name="year" suffix=""/>
-      </date>
+      <term name="page-range-delimiter">-</term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="zh">
     <terms>
+      <term name="anonymous">佚名</term>
+      <term name="edition" form="short">版</term>
       <term name="ibid">同上</term>
-      <term name="page" form="short"/>
-      <term name="anonymous">出版时间不详</term>
+      <term name="no date">出版时间不详</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="page-range-delimiter">&#8212;</term>
+      <term name="editor" form="short">编</term>
+      <term name="compiler" form="short">整理</term>
     </terms>
   </locale>
-  <macro name="author">
+  <macro name="author-en">
     <names variable="author">
-      <name delimiter="、" sort-separator="，"/>
+      <name and="text"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="compiler"/>
+      </substitute>
     </names>
-     </macro>
-      <macro name="editor">
-    <names variable="editor">
-      <name delimiter="、" sort-separator="，"/>
-    </names>
   </macro>
-   <macro name="date">
-  <group prefix="">
-  <choose>
-  <if variable="issued">
-    <date date-parts="year" form="text" variable="issued">
-    <date-part name="year"/>
-    </date>
-  </if>
-  <else>
-  <text term="anonymous"/>
-  </else>
-  </choose>
-  </group>
-  </macro>
-  <macro name="container-title">
-    <text variable="container-title" prefix="《" suffix="》，"/>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author">
+  <macro name="author-zh">
+    <names variable="author">
       <name delimiter="、"/>
+      <label form="short"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="compiler"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="pageField">
+  <macro name="volume-zh">
     <choose>
-      <if type="chapter" match="any">
-        <text variable="page" prefix="第" suffix="页。"/>
+      <if is-numeric="volume">
+        <choose>
+          <if type="classic">
+            <label variable="volume" form="short"/>
+            <number variable="volume"/>
+          </if>
+          <else>
+            <text value="第"/>
+            <number variable="volume"/>
+            <label variable="volume" form="short"/>
+          </else>
+        </choose>
       </if>
-      <else/>
-    </choose>
-  </macro>
-  <macro name="secondAuthor">
-    <names variable="translator" suffix="译">
-      <name delimiter="、" sort-separator="，"/>
-    </names>
-  </macro>
-  <macro name="publisher">
-    <choose>
-      <if type="article article-journal article-magazine article-newspaper" match="any"/>
       <else>
-        <text variable="abstract"/>
+        <text variable="volume"/>
       </else>
     </choose>
   </macro>
-  <macro name="place: publisher">
-    <text variable="publisher-place" suffix="："/>
-    <text variable="publisher" suffix="，"/>
-  </macro>
-  <macro name="en-layout">
-    <names variable="author" suffix=", ">
-      <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-    </names>
+  <macro name="edition-zh">
     <choose>
-      <if type="book" match="any">
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-        <text variable="title" font-style="italic"/>
-        <names variable="translator">
-          <label form="short" prefix=" " suffix=" "/>
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <text variable="publisher-place" prefix=", " suffix=": "/>
-        <text variable="publisher" suffix=", "/>
-        <date date-parts="year" form="numeric" variable="issued"/>
-        <group>
-          <label variable="locator" form="short" prefix=", " suffix=""/>
-          <text variable="locator" suffix=""/>
-        </group>
+      <if is-numeric="edition">
+        <text value="第"/>
+        <number variable="edition"/>
+        <label variable="edition" form="short"/>
       </if>
-      <else-if type="chapter" match="any">
-        <text variable="title" prefix="“" suffix=",” "/>
-        <names variable="editor" prefix="in " suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-        <text variable="container-title" font-style="italic"/>
-        <names variable="translator">
-          <label form="short" prefix=" " suffix=" "/>
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <text variable="publisher-place" prefix=", " suffix=": "/>
-        <text variable="publisher" suffix=", "/>
-        <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
-        <group>
-          <label variable="page" form="short" suffix=""/>
-          <text variable="page" suffix=""/>
-        </group>
-      </else-if>
-      <else-if type="webpage" match="any">
-        <text variable="title" prefix="“" suffix=",” "/>
-        <text variable="container-title" font-style="italic" suffix=", "/>
-        <date form="text" variable="issued" suffix=", "/>
-        <text variable="URL" suffix=""/>
-        <date variable="accessed" prefix=", ">
-          <date-part name="year" suffix="年"/>
-          <date-part name="month" form="numeric" suffix="月"/>
-          <date-part name="day" suffix="日"/>
-        </date>
-      </else-if>
-      <else-if type="paper-conference" match="any">
-          <text macro="author" suffix=", "/>
-          <text variable="title" prefix="“" suffix=",” "/>
-          <text variable="event" suffix=", "/>
-          <text variable="event-place" suffix=", "/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix="" suffix=""/>
-        <group>
-          <label variable="page" form="short" prefix=", " suffix=""/>
-          <text variable="page" suffix=""/>
-        </group>
-        </else-if>
-      <else-if type="thesis" match="any">
-        <text variable="title" font-style="italic" suffix=", "/>
-        <text variable="publisher-place" suffix=": "/>
-        <text variable="publisher" suffix=", "/>
-        <text variable="genre" suffix=" Dissertation, "/>
-        <date date-parts="year" form="numeric" variable="issued"/>
-        <group>
-          <label variable="locator" form="short" prefix=", " suffix=""/>
-          <text variable="locator" suffix=""/>
-        </group>
-      </else-if>
-      <else-if type="article article-journal article-magazine" match="any">
-       <choose>
-       <if variable="locator">
-        <text variable="title" prefix="“" suffix=",” "/>
-        <text variable="container-title" font-style="italic" suffix=", "/>
-        <text variable="volume" prefix="vol. " suffix=", "/>
-        <text variable="issue" prefix="no. " suffix=" "/>
-        <date date-parts="year-month" form="text" variable="issued" prefix="(" suffix=")"/>
-        <group>
-          <label variable="locator" form="short" prefix=", " suffix=""/>
-          <text variable="locator" suffix=""/>
-        </group>
-       </if>
-       <else>
-        <text variable="title" prefix="“" suffix=",” "/>
-        <text variable="container-title" font-style="italic" suffix=", "/>
-        <text variable="volume" prefix="vol. " suffix=", "/>
-        <text variable="issue" prefix="no. " suffix=" "/>
-        <date date-parts="year-month" form="text" variable="issued" prefix="(" suffix=")"/>
-        <group>
-          <label variable="page" form="short" prefix=", " suffix=""/>
-          <text variable="page" suffix=""/>
-        </group>
-       </else>
-       </choose>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 年代（年号）或年月甲子 -->
+  <macro name="original-date-zh">
+    <date variable="original-date">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="title-en">
+    <choose>
+      <if type="book thesis" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <text variable="title" text-case="title" quotes="true"/>
       </else-if>
       <else>
-          <text macro="author" suffix=""/>
-          <text macro="editor" suffix=""/>
-          <text variable="title" prefix="" suffix=""/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix=", " suffix=", "/>
-          <text macro="secondAuthor" prefix=", "/>
-          <text variable="publisher-place" prefix=", " suffix=": "/>
+        <text variable="title" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short-en">
+    <choose>
+      <if type="book thesis" match="any">
+        <text variable="title" form="short" text-case="title" font-style="italic"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <text variable="title" form="short" text-case="title" quotes="true"/>
+      </else-if>
+      <else>
+        <text variable="title" form="short" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-zh">
+    <text variable="title" prefix="《" suffix="》"/>
+  </macro>
+  <macro name="title-short-zh">
+    <text variable="title" form="short" prefix="《" suffix="》"/>
+  </macro>
+  <macro name="title-and-descriptions-zh">
+    <group delimiter="，">
+      <group>
+        <!-- 明清以后的地方志……书名前冠以修纂成书时的年代 -->
+        <choose>
+          <if type="classic" variable="volume-title" match="all">
+            <text macro="original-date-zh"/>
+          </if>
+        </choose>
+        <text macro="title-zh"/>
+        <choose>
+          <if type="classic" variable="volume-title" match="all">
+            <text macro="volume-zh"/>
+            <text variable="volume-title" prefix="《" suffix="》"/>
+          </if>
+          <else-if variable="container-title" match="none">
+            <choose>
+              <if type="classic">
+                <text macro="volume-zh"/>
+                <text variable="volume-title" prefix="《" suffix="》"/>
+              </if>
+              <else>
+                <text macro="edition-zh" prefix="（" suffix="）"/>
+                <text macro="volume-zh"/>
+              </else>
+            </choose>
+          </else-if>
+        </choose>
+      </group>
+      <choose>
+        <if type="classic">
+          <choose>
+            <if variable="volume-title" match="none">
+              <text macro="original-date-zh"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="thesis">
+          <text variable="genre"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="translator-en">
+    <names variable="translator">
+      <label form="short" suffix=" "/>
+      <name and="text"/>
+    </names>
+  </macro>
+  <macro name="translator-zh">
+    <names variable="translator">
+      <name delimiter="、"/>
+      <label form="short"/>
+    </names>
+  </macro>
+  <macro name="issue-zh">
+    <choose>
+      <if is-numeric="issue">
+        <text value="第"/>
+        <number variable="issue"/>
+        <label variable="issue" form="short"/>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-date-zh">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="article-newspaper collection manuscript personal_communication post post-weblog software webpage" match="any">
+            <date variable="issued" form="text"/>
+          </if>
+          <else>
+            <date variable="issued" form="text" date-parts="year"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-newspaper" variable="original-date" match="all">
+        <text macro="original-date-zh"/>
+      </else-if>
+      <else-if type="classic post post-weblog software webpage" match="none">
+        <text term="no date"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="date-en">
+    <choose>
+      <if type="collection manuscript personal_communication" match="any">
+        <date variable="issued" form="text"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <date variable="issued" form="text" date-parts="year-month" prefix="(" suffix=")"/>
+      </else-if>
+      <else>
+        <date variable="issued" form="text" date-parts="year"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-zh">
+    <choose>
+      <if type="paper-conference">
+        <choose>
+          <if variable="container-title">
+            <text macro="issued-date-zh"/>
+          </if>
+          <else-if variable="event-date">
+            <date variable="event-date" form="text"/>
+          </else-if>
+          <else>
+            <text macro="issued-date-zh"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text macro="issued-date-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-periodical-en">
+    <group delimiter=", ">
+      <text variable="container-title" text-case="title" font-style="italic"/>
+      <group delimiter=" ">
+        <label variable="volume" form="short"/>
+        <number variable="volume"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="issue" form="short"/>
+        <number variable="issue"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-periodical-zh">
+    <text variable="container-title" prefix="《" suffix="》"/>
+    <text variable="section" prefix="（" suffix="）"/>
+    <text variable="publisher-place" prefix="（" suffix="）"/>
+    <choose>
+      <if variable="volume">
+        <group delimiter="，">
+          <group>
+            <text macro="volume-zh"/>
+            <text macro="issue-zh"/>
+          </group>
+          <date variable="issued" form="text"/>
+        </group>
+      </if>
+      <else>
+        <text macro="date-zh"/>
+        <text macro="issue-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-newspaper-zh">
+    <group>
+      <text variable="container-title" prefix="《" suffix="》"/>
+      <text variable="publisher-place" prefix="（" suffix="）"/>
+      <group delimiter="，">
+        <group>
+          <text macro="volume-zh"/>
+          <text macro="issue-zh"/>
+        </group>
+        <text macro="date-zh"/>
+        <text variable="section" quotes="true"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-booklike-en">
+    <text term="in" suffix=" "/>
+    <group delimiter=", ">
+      <names variable="editor">
+        <name and="text"/>
+        <label form="short" prefix=", "/>
+      </names>
+      <text variable="container-title" text-case="title" font-style="italic"/>
+    </group>
+  </macro>
+  <macro name="container-booklike-zh">
+    <group delimiter="：">
+      <names variable="editor">
+        <name delimiter="、"/>
+        <label form="short"/>
+      </names>
+      <group>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" prefix="《" suffix="》"/>
+            <choose>
+              <if type="classic" match="none">
+                <text macro="edition-zh" prefix="（" suffix="）"/>
+                <text macro="volume-zh"/>
+              </if>
+              <else-if variable="volume-title" match="none">
+                <text macro="volume-zh"/>
+              </else-if>
+            </choose>
+          </if>
+          <else-if type="paper-conference" variable="event-title">
+            <text variable="event-title"/>
+            <text value="论文"/>
+          </else-if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="series-zh">
+    <text variable="collection-title" prefix="《" suffix="》"/>
+  </macro>
+  <macro name="publisher-en">
+    <choose>
+      <if type="collection manuscript personal_communication" match="any">
+        <group delimiter=", ">
+          <text variable="archive_location"/>
+          <text variable="archive_collection"/>
+          <text variable="archive"/>
+          <choose>
+            <if variable="archive-place">
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <text variable="publisher-place"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
           <text variable="publisher"/>
-          <text variable="archive" suffix=", "/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-zh">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else-if type="paper-conference">
+        <choose>
+          <if variable="container-title">
+            <group delimiter="：">
+              <text variable="publisher-place"/>
+              <text variable="publisher"/>
+            </group>
+          </if>
+          <else>
+            <text variable="event-place"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <group delimiter="：">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive-zh">
+    <choose>
+      <if variable="archive">
+        <group delimiter="，">
           <text variable="archive_location"/>
           <group>
-          <label variable="page" form="short" prefix=", " suffix=""/>
-          <text variable="page" suffix=""/>
+            <text variable="archive"/>
+            <text value="藏"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access-zh">
+    <choose>
+      <if type="post post-weblog software webpage">
+        <group delimiter="，">
+          <text variable="URL"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="source-en">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="translator-en"/>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <group delimiter=" ">
+            <text macro="container-periodical-en"/>
+            <text macro="date-en"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="container-booklike-en"/>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else-if type="collection manuscript personal_communication" match="any">
+          <text macro="date-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else-if type="post post-weblog software webpage" match="any">
+          <text variable="container-title"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else>
+      </choose>
+      <text macro="locator-or-page-en"/>
+    </group>
+  </macro>
+  <macro name="source-zh">
+    <group delimiter="：">
+      <text macro="author-zh"/>
+      <group delimiter="，">
+        <text macro="title-and-descriptions-zh"/>
+        <text macro="translator-zh"/>
+        <choose>
+          <if type="article-journal article-magazine" match="any">
+            <text macro="container-periodical-zh"/>
+          </if>
+          <else-if type="classic">
+            <text macro="container-booklike-zh"/>
+            <text macro="series-zh"/>
+            <text macro="publisher-zh"/>
+            <group>
+              <text macro="date-zh"/>
+              <text macro="edition-zh"/>
+            </group>
+          </else-if>
+          <else-if type="article-newspaper">
+            <text macro="container-newspaper-zh"/>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <text macro="container-booklike-zh"/>
+            <text macro="publisher-zh"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else-if type="post post-weblog software webpage" match="any">
+            <text variable="container-title"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else>
+            <text macro="publisher-zh"/>
+            <text macro="date-zh"/>
+          </else>
+        </choose>
+        <text macro="archive-zh"/>
+        <text macro="access-zh"/>
+        <text macro="locator-or-page-zh"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="page-en">
+    <choose>
+      <if is-numeric="page">
+        <label variable="page" form="short" suffix=" "/>
+        <number variable="page"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="page-zh">
+    <choose>
+      <if is-numeric="page">
+        <text value="第"/>
+        <number variable="page"/>
+        <choose>
+          <if type="article-newspaper">
+            <text value="版"/>
+          </if>
+          <else>
+            <label variable="page" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-en">
+    <choose>
+      <if is-numeric="locator">
+        <label variable="locator" form="short" suffix=" "/>
+        <number variable="locator"/>
+      </if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-zh">
+    <choose>
+      <if is-numeric="locator">
+        <text value="第"/>
+        <number variable="locator"/>
+        <choose>
+          <if type="article-newspaper" locator="page" match="all">
+            <text value="版"/>
+          </if>
+          <else>
+            <label variable="locator" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-or-page-en">
+    <choose>
+      <if variable="locator">
+        <text macro="locator-en"/>
+      </if>
+      <else>
+        <text macro="page-en"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-or-page-zh">
+    <choose>
+      <if variable="locator">
+        <text macro="locator-zh"/>
+      </if>
+      <else>
+        <text macro="page-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="entry-layout-en">
+    <choose>
+      <if position="first">
+        <text macro="source-en"/>
+      </if>
+      <else>
+        <group delimiter="：">
+          <group delimiter=", ">
+            <text macro="author-en"/>
+            <text macro="title-short-en"/>
+            <text macro="locator-en"/>
+          </group>
         </group>
       </else>
     </choose>
   </macro>
-  <macro name="locators">
-    <group>
-      <choose>
-        <if type="book thesis" match="any">
-          <label variable="page" form="short" suffix=""/>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="locators-zh">
-    <group prefix="" suffix="">
-      <choose>
-        <if type="book thesis" match="any">
-          <label variable="locator" form="symbol"/>
-        </if>
-      </choose>
-    </group>
+  <macro name="entry-layout-zh">
+    <choose>
+      <if position="first">
+        <text macro="source-zh"/>
+      </if>
+      <else>
+        <!-- 再次引证时的项目简化 -->
+        <group delimiter="：">
+          <group delimiter="，">
+            <text macro="author-zh"/>
+            <text macro="title-short-zh"/>
+            <text macro="locator-zh"/>
+          </group>
+        </group>
+      </else>
+    </choose>
   </macro>
   <citation>
-    <layout locale="en English en-GB en-gb en-us en-US eng" suffix="." delimiter="; ">
-      <choose>
-        <if position="ibid-with-locator">
-          <group delimiter="">
-            <text term="ibid" suffix=", "/>
-            <group>
-             <label variable="locator" form="short" prefix="" suffix=""/>
-             <text variable="locator" suffix=""/>
-            </group>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
-        </else-if>
-        <else-if position="subsequent" type="book">
-            <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-            <text variable="title" font-style="italic"/>
-            <group>
-             <label variable="locator" form="short" prefix=", " suffix=""/>
-             <text variable="locator" suffix=""/>
-          </group>
-        </else-if>
-        <else-if position="subsequent" type="thesis">
-            <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-            <text variable="title" font-style="italic"/>
-            <group>
-             <label variable="locator" form="short" prefix=", " suffix=""/>
-             <text variable="locator" suffix=""/>
-            </group>
-        </else-if>
-        <else-if position="subsequent" type="article article-journal article-magazine">
-         <choose>
-         <if variable="locator">
-           <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-            <text variable="title" prefix="“" suffix=",” "/>
-            <group>
-             <label variable="locator" form="short" prefix="" suffix=""/>
-             <text variable="locator" suffix=""/>
-            </group>
-         </if>
-         <else>
-            <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-            <text variable="title" prefix="“" suffix="”"/>
-         </else>
-         </choose>
-        </else-if>
-        <else-if position="subsequent" type="paper-conference">
-            <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-        <names variable="editor" prefix="" suffix=", ">
-          <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-          <label form="short" prefix=" "/>
-        </names>
-            <text variable="title" prefix="“" suffix=",” "/>
-            <group>
-              <label variable="page" form="short" prefix="" suffix=""/>
-              <text variable="page" suffix=""/>
-            </group>
-        </else-if>
-        <else-if position="subsequent" type="chapter">
-            <names variable="author" suffix=", ">
-        <name and="text" et-al-min="4" et-al-use-first="1" sort-separator=""/>
-        </names>
-            <text variable="title" prefix="“" suffix=",” "/>
-            <group>
-              <label variable="page" form="short" prefix="" suffix=""/>
-              <text variable="page" suffix=""/>
-            </group>
-        </else-if>
-        <else>
-      <text macro="en-layout"/>
-      </else>
-      </choose>
+    <layout delimiter="。" suffix="。" locale="zh">
+      <text macro="entry-layout-zh"/>
     </layout>
-    <layout suffix="。" delimiter="；">
-      <choose>
-        <if position="ibid-with-locator">
-          <group delimiter="，">
-            <text term="ibid"/>
-            <text macro="locators-zh"/>
-            <text variable="locator" prefix="第" suffix="页"/>
-          </group>
-        </if>
-        <else-if match="any" position="ibid">
-          <text term="ibid"/>
-        </else-if>
-        <else-if position="subsequent">
-          <group delimiter="">
-            <text macro="author" suffix="："/>
-            <text macro="editor" prefix="" suffix="主编："/>
-            <text variable="title" prefix="《" suffix="》"/>
-            <text macro="locators-zh"/>
-            <text variable="locator" prefix="，第" suffix="页"/>
-          </group>
-        </else-if>
-        <else-if type="article article-journal article-magazine" match="any">
-         <choose>
-         <if variable="locator">
-          <text macro="author"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="archive_location" prefix="（" suffix="）"/>
-          <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
-          <text macro="locators-zh"/>
-            <text variable="locator" prefix="，第" suffix="页"/>
-         </if>
-         <else>
-          <text macro="author"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="archive_location" prefix="（" suffix="）"/>
-          <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>         
-          <text variable="page" prefix="，第" suffix="页"/>
-         </else>
-         </choose>
-        </else-if>
-        <else-if type="article-newspaper" match="any">
-          <text macro="author" suffix="："/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="publisher-place" prefix="（" suffix="）"/>
-          <text variable="edition"/>
-          <date form="text" variable="issued"/>
-          <text variable="section" prefix="，" suffix=""/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="chapter" match="any">
-          <text macro="author"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text macro="editor" prefix="" suffix="编："/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text macro="date" prefix="，"/> 
-          <text variable="page" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="webpage" match="any">
-          <text macro="author" suffix="："/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="container-title" suffix="，"/>
-          <date form="text" variable="issued" suffix="，"/>
-          <text variable="URL" prefix=" " suffix="，"/>
-        <date form="text" variable="accessed" suffix=""/>
-        </else-if>
-        <else-if type="paper-conference" match="any">
-          <text macro="author" suffix="："/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="event" suffix="，"/>
-          <text variable="event-place" suffix="，"/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix="" suffix=""/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="thesis" match="any">
-          <text macro="author"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text variable="genre" suffix="学位论文"/>
-          <text variable="publisher" prefix="，"/>
-          <date date-parts="year" form="text" variable="issued" prefix="，"/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="book" match="any">
-          <text macro="author" suffix="："/>
-          <text macro="editor" suffix="主编："/>
-          <text variable="title" prefix="《" suffix="》"/>
-          <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text macro="date" prefix="，"/> 
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else>
-          <text macro="author" suffix=""/>
-          <text macro="editor" suffix="主编"/>
-          <text variable="title" prefix="《" suffix="》"/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text variable="archive" suffix="，"/>
-          <text variable="archive_location"/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else>
-      </choose>
+    <layout delimiter="." suffix=". ">
+      <text macro="entry-layout-en"/>
     </layout>
   </citation>
-  <bibliography>
-    <sort>
-      <key variable="author"/>
-    </sort>
-    <layout locale="en English en-GB en-gb en-us en-US eng" suffix="." delimiter="; ">
-      <text macro="en-layout"/>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <layout suffix="。" locale="zh">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="source-zh"/>
     </layout>
-     <layout suffix="。" delimiter="；">
-      <choose>
-        <if type="article article-journal article-magazine" match="any">
-          <text macro="author"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="archive_location" prefix="（" suffix="）"/>
-          <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
-        </if>
-        <else-if type="article-newspaper" match="any">
-          <text macro="author" suffix="："/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="publisher-place" prefix="（" suffix="）"/>
-          <text variable="edition"/>
-          <date form="text" variable="issued"/>
-          <text variable="section" prefix="，" suffix=""/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="chapter" match="any">
-          <text macro="author"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text macro="editor" prefix="" suffix="编："/>
-          <text variable="container-title" prefix="《" suffix="》"/>
-          <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text macro="date" prefix="，"/> 
-          <text variable="page" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="webpage" match="any">
-          <text macro="author" suffix="："/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="container-title" suffix="，"/>
-          <date form="text" variable="issued" suffix="，"/>
-          <text variable="URL" prefix=" " suffix="，"/>
-        <date form="text" variable="accessed" suffix=""/>
-        </else-if>
-        <else-if type="paper-conference" match="any">
-          <text macro="author" suffix="："/>
-          <text variable="title" prefix="《" suffix="》，"/>
-          <text variable="event" suffix="，"/>
-          <text variable="event-place" suffix="，"/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix="" suffix=""/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="thesis" match="any">
-          <text macro="author"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="title" prefix="：《" suffix="》，"/>
-          <text variable="genre" suffix="学位论文"/>
-          <text variable="publisher" prefix="，"/>
-          <date date-parts="year" form="text" variable="issued" prefix="，"/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else-if type="book" match="any">
-          <text macro="author" suffix="："/>
-          <text macro="editor" suffix="主编："/>
-          <text variable="title" prefix="《" suffix="》"/>
-          <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text macro="date" prefix="，"/> 
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else-if>
-        <else>
-          <text macro="author" suffix=""/>
-          <text macro="editor" suffix="主编"/>
-          <text variable="title" prefix="《" suffix="》"/>
-          <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
-          <text macro="secondAuthor" prefix="，"/>
-          <text variable="publisher-place" prefix="，" suffix="："/>
-          <text variable="publisher"/>
-          <text variable="archive" suffix="，"/>
-          <text variable="archive_location"/>
-          <text macro="locators-zh"/>
-          <text variable="locator" prefix="，第" suffix="页"/>
-        </else>
-      </choose>
+    <layout suffix=".">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="source-en"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
主要修改有：

1. “上册”填在 `volume` 字段，不再填到 `edition`。我的理解是，与“册”最接近的字段是“卷”。所以目前的处理方式是，如果 `volume` 是数字则输出 `第x卷`，否则原文输出。同样，“《鲁迅全集》：第9册”将“第9册”完整地填入 `volume`。
1. Zotero 和 CSL 没有“主编”对应的字段，所以 `editor` 的责任方式只能显示为“编”。
1. 中文示例的页码连接号（`page-range-delimiter`）为一字线（em dash），英文示例的是 hyphen。
1. 古籍可以在 `Extra` 中填写 `Type: classic`，在 CSL 中可以按照 `classic` 类型处理。
1. “活字本”、“点校本”、“影印本”跟适合填在 `edition` 字段。
1. “杨钟羲:《雪桥诗话续集》卷 5，沈阳:辽沈书社，1991 年影印本，上册，第461页下栏”的“上册，第461页下栏”整体放入 `locator`。
1. “四库全书存目丛书”改在 `series` 字段。
1. 地方志和常用基本典籍可以使用 `Extra` 解决。
1. “年月甲子”填在 `Extra` 的 `Original Date` 字段。
1. 期刊文章有卷号时使用“卷期，出版年月”格式，无卷号时使用“年期”格式。
1. 期刊的出版地点改在 `Extra` 的 `Place` 字段，不宜借用 `archive_location` 字段。另外版别（如“文史哲版”）填在 `Extra` 的 `Section` 字段。不过像 GB/T 7714 和《法学引注手册》都要求期刊的“社会科学版”“人文社会科学版”属于期刊名称的一部分，用括号置于书名号内。
1. 报纸的版次相当于页码，应该填在 `page` 不是 `edition`。
1. 会议论文如果有会议论文集的题名时优先按照“析出文献”的格式处理，如果没有论文集题名再使用会议名称。
1. 《傅良佐致国务院电》和 Nixon to Kissinger 的类型更适合使用“Letter”（对应 CSL 的 `personal_communication`）。
1. 根据 [Zotero 文档](https://www.zotero.org/support/kb/item_types_and_fields#fields_related_to_when_and_how_items_were_accessed)，“北洋档案 1011—5961” 应该填在 `Loc. in Archive`（存档位置）字段，“Box 1032, NSC Files, Nixon Presidential Material Project (NPMP)”应该填在 `archive`（档案，可能翻译为“档案馆”更合适）字段。同样，“National Archives II, College Park, MD” 应该填在 `archive`字段，“Box 1032, NSC Files, Nixon Presidential Material Project (NPMP)”应该填在 `Loc. in Archive`字段，
1. 再次引证时,严格按照要求没有使用“同上”和“ibid”，可以再增加 `-with-ibid` 的修改版。

详细的修改见 [zepinglee/csl-development@401e339:test-data.json](https://github.com/zepinglee/csl-development/commit/401e3399df4c113e8199cb6478b59a14bd1819b1#diff-1306092ec0c9618b7d76cb7e88b0f9b59197ad600cb714fec9b449f929ca37bb)。

另外还有疑问：

- 原样式中设置了 `et-al-min="4" et-al-use-first="1"`，但是《规定》中并没有要求超过多少数量的姓名要省略为“等”或“et al.”。
