### PR TITLE
调整《中国社会科学》样式结构

### DIFF
--- a/中国社会科学.csl
+++ b/中国社会科学.csl
@@ -36,7 +36,7 @@
       <term name="open-inner-quote">‘</term>
       <term name="close-inner-quote">’</term>
       <term name="page-range-delimiter">&#8212;</term>
-      <term name="editor" form="short">编</term>
+      <term name="editor" form="short">主编</term>
       <term name="compiler" form="short">整理</term>
     </terms>
   </locale>

--- a/中国社会科学.csl
+++ b/中国社会科学.csl
@@ -16,11 +16,12 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <category field="humanities"/>
-    <updated>2022-11-04T20:06:00+08:00</updated>
+    <updated>2022-11-12T18:15:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
+      <!-- 英文页码的连接号使用 hyphen -->
       <term name="page-range-delimiter">-</term>
       <term name="translator" form="short">trans.</term>
     </terms>
@@ -30,11 +31,13 @@
       <term name="anonymous">佚名</term>
       <term name="edition" form="short">版</term>
       <term name="ibid">同上</term>
+      <term name="in">载</term>
       <term name="no date">出版时间不详</term>
       <term name="open-quote">“</term>
       <term name="close-quote">”</term>
       <term name="open-inner-quote">‘</term>
       <term name="close-inner-quote">’</term>
+      <!-- 中文页码的连接号使用一字线（em dash） -->
       <term name="page-range-delimiter">&#8212;</term>
       <term name="editor" form="short">主编</term>
       <term name="compiler" form="short">整理</term>
@@ -60,6 +63,17 @@
       </substitute>
     </names>
   </macro>
+  <macro name="volume-en">
+    <choose>
+      <if is-numeric="volume">
+        <label variable="volume" form="short"/>
+        <number variable="volume"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="volume-zh">
     <choose>
       <if is-numeric="volume">
@@ -77,6 +91,17 @@
       </if>
       <else>
         <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition-en">
+    <choose>
+      <if is-numeric="edition">
+        <number variable="edition" form="ordinal"/>
+        <label variable="edition" form="short" prefix=" "/>
+      </if>
+      <else>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -100,78 +125,103 @@
   </macro>
   <macro name="title-en">
     <choose>
-      <if type="book thesis" match="any">
-        <text variable="title" text-case="title" font-style="italic"/>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+      <if type="article-journal article-magazine article-newspaper chapter paper-conference report" match="any">
         <text variable="title" text-case="title" quotes="true"/>
-      </else-if>
-      <else>
-        <text variable="title" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-short-en">
-    <choose>
-      <if type="book thesis" match="any">
-        <text variable="title" form="short" text-case="title" font-style="italic"/>
       </if>
-      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
-        <text variable="title" form="short" text-case="title" quotes="true"/>
+      <else-if type="thesis" match="any">
+        <group delimiter=", ">
+          <!-- 《规定》中未要求，但是按照 ASA 样式学位论文使用引号 -->
+          <text variable="title" text-case="title" quotes="true"/>
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="title"/>
+            </if>
+            <else>
+              <text value="Ph.D. Dissertation"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="collection manuscript personal_communication post post-weblog software webpage" match="any">
+        <text variable="title" text-case="title"/>
       </else-if>
       <else>
-        <text variable="title" form="short" text-case="title"/>
+        <group delimiter=", ">
+          <text variable="title" text-case="title" font-style="italic"/>
+          <text macro="volume-en"/>
+        </group>
       </else>
     </choose>
   </macro>
   <macro name="title-zh">
-    <text variable="title" prefix="《" suffix="》"/>
-  </macro>
-  <macro name="title-short-zh">
-    <text variable="title" form="short" prefix="《" suffix="》"/>
-  </macro>
-  <macro name="title-and-descriptions-zh">
-    <group delimiter="，">
-      <group>
-        <!-- 明清以后的地方志……书名前冠以修纂成书时的年代 -->
-        <choose>
-          <if type="classic" variable="volume-title" match="all">
-            <text macro="original-date-zh"/>
-          </if>
-        </choose>
-        <text macro="title-zh"/>
-        <choose>
-          <if type="classic" variable="volume-title" match="all">
-            <text macro="volume-zh"/>
-            <text variable="volume-title" prefix="《" suffix="》"/>
-          </if>
-          <else-if variable="container-title" match="none">
+    <choose>
+      <if type="classic">
+        <group delimiter="，">
+          <group>
+            <!-- 明清以后的地方志……书名前冠以修纂成书时的年代 -->
             <choose>
-              <if type="classic">
+              <if variable="volume-title">
+                <text macro="original-date-zh"/>
+              </if>
+            </choose>
+            <text variable="title" prefix="《" suffix="》"/>
+            <choose>
+              <if variable="volume-title">
                 <text macro="volume-zh"/>
                 <text variable="volume-title" prefix="《" suffix="》"/>
               </if>
-              <else>
-                <text macro="edition-zh" prefix="（" suffix="）"/>
+              <else-if variable="container-title" match="none">
                 <text macro="volume-zh"/>
-              </else>
+                <text variable="volume-title" prefix="《" suffix="》"/>
+              </else-if>
             </choose>
-          </else-if>
-        </choose>
-      </group>
-      <choose>
-        <if type="classic">
+          </group>
           <choose>
             <if variable="volume-title" match="none">
               <text macro="original-date-zh"/>
             </if>
           </choose>
-        </if>
-        <else-if type="thesis">
-          <text variable="genre"/>
-        </else-if>
-      </choose>
-    </group>
+        </group>
+      </if>
+      <else-if type="thesis">
+        <group delimiter="，">
+          <text variable="title" prefix="《" suffix="》"/>
+          <choose>
+            <if variable="genre">
+              <text variable="genre"/>
+            </if>
+            <else>
+              <text value="博士学位论文"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else>
+        <text variable="title" prefix="《" suffix="》"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <text macro="edition-zh" prefix="（" suffix="）"/>
+            <text macro="volume-zh"/>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short-en">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper chapter paper-conference report thesis" match="any">
+        <text variable="title" form="short" text-case="title" quotes="true"/>
+      </if>
+      <else-if type="collection manuscript personal_communication post post-weblog software webpage" match="any">
+        <text variable="title" form="short" text-case="title"/>
+      </else-if>
+      <else>
+        <text variable="title" form="short" text-case="title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short-zh">
+    <text variable="title" form="short" prefix="《" suffix="》"/>
   </macro>
   <macro name="translator-en">
     <names variable="translator">
@@ -185,19 +235,20 @@
       <label form="short"/>
     </names>
   </macro>
-  <macro name="issue-zh">
+  <macro name="date-en">
     <choose>
-      <if is-numeric="issue">
-        <text value="第"/>
-        <number variable="issue"/>
-        <label variable="issue" form="short"/>
+      <if type="collection manuscript personal_communication" match="any">
+        <date variable="issued" form="text"/>
       </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <date variable="issued" form="text" date-parts="year-month" prefix="(" suffix=")"/>
+      </else-if>
       <else>
-        <text variable="issue"/>
+        <date variable="issued" form="text" date-parts="year"/>
       </else>
     </choose>
   </macro>
-  <macro name="issued-date-zh">
+  <macro name="date-zh">
     <choose>
       <if variable="issued">
         <choose>
@@ -217,36 +268,15 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-en">
+  <macro name="issue-zh">
     <choose>
-      <if type="collection manuscript personal_communication" match="any">
-        <date variable="issued" form="text"/>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued" form="text" date-parts="year-month" prefix="(" suffix=")"/>
-      </else-if>
-      <else>
-        <date variable="issued" form="text" date-parts="year"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-zh">
-    <choose>
-      <if type="paper-conference">
-        <choose>
-          <if variable="container-title">
-            <text macro="issued-date-zh"/>
-          </if>
-          <else-if variable="event-date">
-            <date variable="event-date" form="text"/>
-          </else-if>
-          <else>
-            <text macro="issued-date-zh"/>
-          </else>
-        </choose>
+      <if is-numeric="issue">
+        <text value="第"/>
+        <number variable="issue"/>
+        <label variable="issue" form="short"/>
       </if>
       <else>
-        <text macro="issued-date-zh"/>
+        <text variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -340,20 +370,8 @@
   </macro>
   <macro name="publisher-en">
     <choose>
-      <if type="collection manuscript personal_communication" match="any">
-        <group delimiter=", ">
-          <text variable="archive_location"/>
-          <text variable="archive_collection"/>
-          <text variable="archive"/>
-          <choose>
-            <if variable="archive-place">
-              <text variable="archive-place"/>
-            </if>
-            <else>
-              <text variable="publisher-place"/>
-            </else>
-          </choose>
-        </group>
+      <if type="thesis">
+        <text variable="publisher"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -368,19 +386,6 @@
       <if type="thesis">
         <text variable="publisher"/>
       </if>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="container-title">
-            <group delimiter="：">
-              <text variable="publisher-place"/>
-              <text variable="publisher"/>
-            </group>
-          </if>
-          <else>
-            <text variable="event-place"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <group delimiter="：">
           <text variable="publisher-place"/>
@@ -389,15 +394,95 @@
       </else>
     </choose>
   </macro>
-  <macro name="archive-zh">
+  <macro name="event-en">
     <choose>
-      <if variable="archive">
+      <if variable="container-title" match="none">
         <group delimiter="，">
-          <text variable="archive_location"/>
-          <group>
-            <text variable="archive"/>
-            <text value="藏"/>
+          <group delimiter=" ">
+            <text value="Paper Prepared for"/>
+            <text variable="event-title"/>
           </group>
+          <names variable="organizer">
+            <name delimiter="、"/>
+            <substitute>
+              <!-- 用户填写在错误字段的情况 -->
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </substitute>
+          </names>
+          <choose>
+            <if variable="event-date">
+              <date variable="event-date" form="text"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-zh">
+    <choose>
+      <if variable="container-title" match="none">
+        <group delimiter="，">
+          <group>
+            <text variable="event-title"/>
+            <text value="论文"/>
+          </group>
+          <names variable="organizer">
+            <name delimiter="、"/>
+            <substitute>
+              <!-- 用户填写在错误字段的情况 -->
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </substitute>
+          </names>
+          <choose>
+            <if variable="event-date">
+              <date variable="event-date" form="text"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-en">
+    <group delimiter=", ">
+      <text variable="archive_location"/>
+      <text variable="archive_collection"/>
+      <text variable="archive"/>
+      <choose>
+        <if variable="archive-place">
+          <text variable="archive-place"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="archive-zh">
+    <group delimiter="，">
+      <group>
+        <text variable="archive_collection"/>
+        <text variable="archive_location"/>
+      </group>
+      <group>
+        <text variable="archive"/>
+        <text value="藏"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="access-en">
+    <choose>
+      <if type="post post-weblog software webpage">
+        <group delimiter="，">
+          <text variable="URL"/>
+          <date variable="accessed" form="text"/>
         </group>
       </if>
     </choose>
@@ -411,81 +496,6 @@
         </group>
       </if>
     </choose>
-  </macro>
-  <macro name="source-en">
-    <group delimiter=", ">
-      <text macro="author-en"/>
-      <text macro="title-en"/>
-      <text macro="translator-en"/>
-      <choose>
-        <if type="article-journal article-magazine article-newspaper" match="any">
-          <group delimiter=" ">
-            <text macro="container-periodical-en"/>
-            <text macro="date-en"/>
-          </group>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <text macro="container-booklike-en"/>
-          <text macro="publisher-en"/>
-          <text macro="date-en"/>
-        </else-if>
-        <else-if type="collection manuscript personal_communication" match="any">
-          <text macro="date-en"/>
-          <text macro="publisher-en"/>
-        </else-if>
-        <else-if type="post post-weblog software webpage" match="any">
-          <text variable="container-title"/>
-          <text macro="date-en"/>
-        </else-if>
-        <else>
-          <text macro="publisher-en"/>
-          <text macro="date-en"/>
-        </else>
-      </choose>
-      <text macro="locator-or-page-en"/>
-    </group>
-  </macro>
-  <macro name="source-zh">
-    <group delimiter="：">
-      <text macro="author-zh"/>
-      <group delimiter="，">
-        <text macro="title-and-descriptions-zh"/>
-        <text macro="translator-zh"/>
-        <choose>
-          <if type="article-journal article-magazine" match="any">
-            <text macro="container-periodical-zh"/>
-          </if>
-          <else-if type="classic">
-            <text macro="container-booklike-zh"/>
-            <text macro="series-zh"/>
-            <text macro="publisher-zh"/>
-            <group>
-              <text macro="date-zh"/>
-              <text macro="edition-zh"/>
-            </group>
-          </else-if>
-          <else-if type="article-newspaper">
-            <text macro="container-newspaper-zh"/>
-          </else-if>
-          <else-if type="chapter paper-conference" match="any">
-            <text macro="container-booklike-zh"/>
-            <text macro="publisher-zh"/>
-            <text macro="date-zh"/>
-          </else-if>
-          <else-if type="post post-weblog software webpage" match="any">
-            <text variable="container-title"/>
-            <text macro="date-zh"/>
-          </else-if>
-          <else>
-            <text macro="publisher-zh"/>
-            <text macro="date-zh"/>
-          </else>
-        </choose>
-        <text macro="archive-zh"/>
-        <text macro="access-zh"/>
-        <text macro="locator-or-page-zh"/>
-      </group>
-    </group>
   </macro>
   <macro name="page-en">
     <choose>
@@ -566,6 +576,109 @@
         <text macro="page-zh"/>
       </else>
     </choose>
+  </macro>
+  <macro name="source-en">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="translator-en"/>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <group delimiter=" ">
+            <text macro="container-periodical-en"/>
+            <text macro="date-en"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="container-booklike-en"/>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <choose>
+            <if variable="container-title">
+              <text macro="container-booklike-en"/>
+              <text macro="publisher-en"/>
+              <text macro="date-en"/>
+            </if>
+            <else>
+              <text macro="event-en"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="collection manuscript personal_communication" match="any">
+          <text macro="date-en"/>
+          <text macro="archive-en"/>
+        </else-if>
+        <else-if type="post post-weblog software webpage" match="any">
+          <text variable="container-title"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else>
+      </choose>
+      <text macro="access-en"/>
+      <text macro="locator-or-page-en"/>
+    </group>
+  </macro>
+  <macro name="source-zh">
+    <group delimiter="：">
+      <text macro="author-zh"/>
+      <group delimiter="，">
+        <text macro="title-zh"/>
+        <text macro="translator-zh"/>
+        <choose>
+          <if type="article-journal article-magazine" match="any">
+            <text macro="container-periodical-zh"/>
+          </if>
+          <else-if type="classic">
+            <text macro="container-booklike-zh"/>
+            <text macro="series-zh"/>
+            <text macro="publisher-zh"/>
+            <group>
+              <text macro="date-zh"/>
+              <text macro="edition-zh"/>
+            </group>
+          </else-if>
+          <else-if type="article-newspaper">
+            <text macro="container-newspaper-zh"/>
+          </else-if>
+          <else-if type="chapter">
+            <text macro="container-booklike-zh"/>
+            <text macro="publisher-zh"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else-if type="paper-conference">
+            <choose>
+              <if variable="container-title">
+                <text macro="container-booklike-zh"/>
+                <text macro="publisher-zh"/>
+                <text macro="date-zh"/>
+              </if>
+              <else>
+                <text macro="event-zh"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="collection manuscript personal_communication" match="any">
+            <text macro="date-zh"/>
+            <text macro="archive-zh"/>
+          </else-if>
+          <else-if type="post post-weblog software webpage" match="any">
+            <text variable="container-title"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else>
+            <text macro="publisher-zh"/>
+            <text macro="date-zh"/>
+          </else>
+        </choose>
+        <text macro="access-zh"/>
+        <text macro="locator-or-page-zh"/>
+      </group>
+    </group>
   </macro>
   <macro name="entry-layout-en">
     <choose>


### PR DESCRIPTION
1. editor 改为“主编”；
2. 调整样式结构，示例的输出不变。