### PR TITLE
修正中文逗号

### DIFF
--- a/世界经济与政治.csl
+++ b/世界经济与政治.csl
@@ -17,7 +17,7 @@
     <category citation-format="note"/>
     <category field="political_science"/>
     <category field="social_science"/>
-    <updated>2022-11-04T20:06:00+08:00</updated>
+    <updated>2023-07-02T19:31:51+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -330,7 +330,7 @@
   <macro name="event-en">
     <choose>
       <if variable="container-title" match="none">
-        <group delimiter="，">
+        <group delimiter=", ">
           <group delimiter=" ">
             <text value="Paper Prepared for"/>
             <text variable="event-title"/>
@@ -604,8 +604,8 @@
           <else-if type="chapter" match="any">
             <text macro="container-booklike-zh"/>
             <group>
-            <text macro="publisher-zh"/>
-            <text macro="date-zh"/>
+              <text macro="publisher-zh"/>
+              <text macro="date-zh"/>
             </group>
           </else-if>
           <else-if type="thesis">
@@ -660,12 +660,10 @@
         <text macro="source-en"/>
       </if>
       <else>
-        <group delimiter="：">
-          <group delimiter=", ">
-            <text macro="author-en"/>
-            <text macro="title-short-en"/>
-            <text macro="locator-en"/>
-          </group>
+        <group delimiter=", ">
+          <text macro="author-en"/>
+          <text macro="title-short-en"/>
+          <text macro="locator-en"/>
         </group>
       </else>
     </choose>
@@ -677,12 +675,10 @@
       </if>
       <else>
         <!-- 再次引证时的项目简化 -->
-        <group delimiter="：">
-          <group delimiter="，">
-            <text macro="author-zh"/>
-            <text macro="title-short-zh"/>
-            <text macro="locator-zh"/>
-          </group>
+        <group delimiter="，">
+          <text macro="author-zh"/>
+          <text macro="title-short-zh"/>
+          <text macro="locator-zh"/>
         </group>
       </else>
     </choose>
@@ -691,7 +687,7 @@
     <layout delimiter="；" suffix="。" locale="zh">
       <text macro="entry-layout-zh"/>
     </layout>
-    <layout delimiter="; " suffix=". ">
+    <layout delimiter="; " suffix=".">
       <text macro="entry-layout-en"/>
     </layout>
   </citation>

--- a/中国社会科学.csl
+++ b/中国社会科学.csl
@@ -16,7 +16,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <category field="humanities"/>
-    <updated>2022-11-12T18:15:00+08:00</updated>
+    <updated>2023-07-02T19:51:59+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -686,11 +686,11 @@
         <text macro="source-en"/>
       </if>
       <else>
-          <group delimiter=", ">
-            <text macro="author-en"/>
-            <text macro="title-short-en"/>
-            <text macro="locator-en"/>
-          </group>
+        <group delimiter=", ">
+          <text macro="author-en"/>
+          <text macro="title-short-en"/>
+          <text macro="locator-en"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -701,11 +701,11 @@
       </if>
       <else>
         <!-- 再次引证时的项目简化 -->
-          <group delimiter="，">
-            <text macro="author-zh"/>
-            <text macro="title-short-zh"/>
-            <text macro="locator-zh"/>
-          </group>
+        <group delimiter="，">
+          <text macro="author-zh"/>
+          <text macro="title-short-zh"/>
+          <text macro="locator-zh"/>
+        </group>
       </else>
     </choose>
   </macro>

--- a/国际政治研究.csl
+++ b/国际政治研究.csl
@@ -4,10 +4,10 @@
     default-locale="en-US">
     <info>
         <title>国际政治研究</title>
-        <id>http://www.zotero.org/styles/the-journal-of-international-politics</id>
-        <link href="http://www.zotero.org/styles/the-journal-of-international-politics" rel="self" />
-        <link href="http://www.zotero.org/styles/social-sciences-in-china" rel="template" />
-        <link href="http://www.iwep.org.cn/cbw/cbw_xsqk/xsqk_sjjjyzz/xsqk_zsgf/" rel="documentation" />
+        <id>http://www.zotero.org/styles/the-journal-of-international-studies</id>
+        <link href="http://www.zotero.org/styles/the-journal-of-international-studies" rel="self" />
+        <link href="http://www.zotero.org/styles/journal-of-world-economics-and-politics" rel="template" />
+        <link href="https://www.jis.pku.edu.cn/Zhushi1407/1102984.htm" rel="documentation" />
         <author>
             <name>Edward Zhou</name>
             <email>edwardzhoujiaxi@gmail.com</email>
@@ -19,7 +19,7 @@
         <category citation-format="note" />
         <category field="political_science" />
         <category field="social_science" />
-        <updated>2023-06-27</updated>
+        <updated>2023-07-02T19:50:45+08:00</updated>
         <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under
             a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     </info>
@@ -50,9 +50,9 @@
     <locale>
         <terms>
             <date variable="accessed">
-                    <date-part name="year" suffix="-"/>
-                    <date-part name="month" form="numeric" suffix="-"/>
-                    <date-part name="day"/>
+                <date-part name="year" suffix="-"/>
+                <date-part name="month" form="numeric" suffix="-"/>
+                <date-part name="day"/>
             </date>
         </terms>
     </locale>
@@ -185,17 +185,17 @@
             </else>
         </choose>
     </macro>
-  <macro name="title-zh">
-    <group>
-      <text variable="title" prefix="《" suffix="》"/>
-      <choose>
-        <if variable="container-title" match="none">
-          <text macro="edition-zh" prefix="（" suffix="）"/>
-          <text macro="volume-zh"/>
-        </if>
-      </choose>
-    </group>
-  </macro>
+    <macro name="title-zh">
+        <group>
+            <text variable="title" prefix="《" suffix="》"/>
+            <choose>
+                <if variable="container-title" match="none">
+                    <text macro="edition-zh" prefix="（" suffix="）"/>
+                    <text macro="volume-zh"/>
+                </if>
+            </choose>
+        </group>
+    </macro>
     <macro name="title-short-en">
         <choose>
             <if
@@ -265,8 +265,8 @@
         </group>
     </macro>
     <macro name="container-periodical-zh">
-            <text variable="container-title" prefix="《" suffix="》" />
-            <text macro="date-zh" />
+        <text variable="container-title" prefix="《" suffix="》" />
+        <text macro="date-zh" />
         <text macro="issue-zh" />
     </macro>
     <macro name="container-booklike-en">
@@ -293,39 +293,39 @@
         </choose>
     </macro>
     <macro name="container-newspaper-zh">
-    <group>
-      <text variable="container-title" prefix="《" suffix="》"/>
-      <text variable="publisher-place" prefix="（" suffix="）"/>
         <group>
-          <text macro="volume-zh"/>
-          <text macro="issue-zh"/>
+            <text variable="container-title" prefix="《" suffix="》"/>
+            <text variable="publisher-place" prefix="（" suffix="）"/>
+            <group>
+                <text macro="volume-zh"/>
+                <text macro="issue-zh"/>
+            </group>
+            <text macro="date-zh"/>
+            <text variable="section"/>
         </group>
-        <text macro="date-zh"/>
-        <text variable="section"/>
-    </group>
-  </macro>
-  <macro name="publisher-en">
-    <choose>
-      <if type="report">
-        <group delimiter=", ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
+    </macro>
+    <macro name="publisher-en">
+        <choose>
+            <if type="report">
+                <group delimiter=", ">
+                    <text variable="publisher"/>
+                    <text variable="publisher-place"/>
+                </group>
+            </if>
+            <else>
+                <group delimiter=": ">
+                    <text variable="publisher-place"/>
+                    <text variable="publisher"/>
+                </group>
+            </else>
+        </choose>
+    </macro>
+    <macro name="publisher-zh">
+        <group delimiter="：">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
         </group>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publisher-zh">
-    <group delimiter="：">
-    <text variable="publisher-place"/>
-    <text variable="publisher"/>
-    </group>
-  </macro>
+    </macro>
     <macro name="event-en">
         <choose>
             <if variable="container-title" match="none">
@@ -426,26 +426,26 @@
             </group>
         </group>
     </macro>
-  <macro name="access-en">
-    <choose>
-      <if type="post post-weblog software webpage">
-        <group delimiter=", ">
-          <text variable="URL"/>
-            <date variable="accessed"/>
-         </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="access-zh">
-    <choose>
-      <if type="post post-weblog software webpage">
-        <group delimiter="，">
-          <text variable="URL"/>
-            <date variable="accessed"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
+    <macro name="access-en">
+        <choose>
+            <if type="post post-weblog software webpage">
+                <group delimiter=", ">
+                    <text variable="URL"/>
+                    <date variable="accessed"/>
+                </group>
+            </if>
+        </choose>
+    </macro>
+    <macro name="access-zh">
+        <choose>
+            <if type="post post-weblog software webpage">
+                <group delimiter="，">
+                    <text variable="URL"/>
+                    <date variable="accessed"/>
+                </group>
+            </if>
+        </choose>
+    </macro>
     <macro name="page-en">
         <choose>
             <if is-numeric="page">
@@ -579,86 +579,84 @@
             <text macro="locator-or-page-en" />
         </group>
     </macro>
-  <macro name="source-zh">
-      <text variable="archive_location" prefix="〔" suffix="〕"/>
-      <text macro="author-zh" suffix="："/>
+    <macro name="source-zh">
+        <text variable="archive_location" prefix="〔" suffix="〕"/>
+        <text macro="author-zh" suffix="："/>
         <text macro="title-zh"/>
         <text macro="translator-zh"/>
         <choose>
-          <if type="article-journal article-magazine" match="any">
-            <text macro="container-periodical-zh" prefix="，"/>
-          </if>
-          <else-if type="classic">
-            <text macro="container-booklike-zh" prefix="，"/>
-            <text macro="series-zh"/>
-            <text macro="publisher-zh" prefix="，"/>
-            <group>
-              <text macro="date-zh"/>
-              <text macro="edition-zh"/>
-            </group>
-          </else-if>
-          <else-if type="article-newspaper">
-            <text macro="container-newspaper-zh" prefix="，"/>
-          </else-if>
-          <else-if type="chapter">
-            <text macro="container-booklike-zh" prefix="，"/>
-            <text macro="publisher-zh" prefix="，"/>
-            <text macro="date-zh" suffix="版"/>
-          </else-if>
-          <else-if type="thesis">
-              <text variable="publisher" prefix="，"/>
-             <group delimiter="，">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre"/>
-                </if>
-                <else>
-                  <text value="博士学位论文"/>
-                </else>
-              </choose>
-              <text macro="date-zh"/>
-              </group>
-          </else-if>
-          <else-if type="paper-conference">
-            <choose>
-              <if variable="container-title">
+            <if type="article-journal article-magazine" match="any">
+                <text macro="container-periodical-zh" prefix="，"/>
+            </if>
+            <else-if type="classic">
+                <text macro="container-booklike-zh" prefix="，"/>
+                <text macro="series-zh"/>
+                <text macro="publisher-zh" prefix="，"/>
+                <group>
+                    <text macro="date-zh"/>
+                    <text macro="edition-zh"/>
+                </group>
+            </else-if>
+            <else-if type="article-newspaper">
+                <text macro="container-newspaper-zh" prefix="，"/>
+            </else-if>
+            <else-if type="chapter">
                 <text macro="container-booklike-zh" prefix="，"/>
                 <text macro="publisher-zh" prefix="，"/>
+                <text macro="date-zh" suffix="版"/>
+            </else-if>
+            <else-if type="thesis">
+                <text variable="publisher" prefix="，"/>
+                <group delimiter="，">
+                    <choose>
+                        <if variable="genre">
+                            <text variable="genre"/>
+                        </if>
+                        <else>
+                            <text value="博士学位论文"/>
+                        </else>
+                    </choose>
+                    <text macro="date-zh"/>
+                </group>
+            </else-if>
+            <else-if type="paper-conference">
+                <choose>
+                    <if variable="container-title">
+                        <text macro="container-booklike-zh" prefix="，"/>
+                        <text macro="publisher-zh" prefix="，"/>
+                        <text macro="date-zh"/>
+                    </if>
+                    <else>
+                        <text macro="event-zh" prefix="，"/>
+                    </else>
+                </choose>
+            </else-if>
+            <else-if type="collection manuscript personal_communication" match="any">
                 <text macro="date-zh"/>
-              </if>
-              <else>
-                <text macro="event-zh" prefix="，"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if type="collection manuscript personal_communication" match="any">
-            <text macro="date-zh"/>
-            <text macro="archive-zh"/>
-          </else-if>
-          <else-if type="post post-weblog software webpage" match="any">
-            <text variable="container-title" prefix="，"/>
-            <text macro="date-zh" prefix="，"/>
-          </else-if>
-          <else>
-            <text macro="publisher-zh" prefix="，"/>
-            <text macro="date-zh" suffix="版"/>
-          </else>
+                <text macro="archive-zh"/>
+            </else-if>
+            <else-if type="post post-weblog software webpage" match="any">
+                <text variable="container-title" prefix="，"/>
+                <text macro="date-zh" prefix="，"/>
+            </else-if>
+            <else>
+                <text macro="publisher-zh" prefix="，"/>
+                <text macro="date-zh" suffix="版"/>
+            </else>
         </choose>
         <text macro="access-zh" prefix="，"/>
         <text macro="locator-or-page-zh" prefix="，"/>
-  </macro>
+    </macro>
     <macro name="entry-layout-en">
         <choose>
             <if position="first">
                 <text macro="source-en" />
             </if>
             <else>
-                <group delimiter="：">
-                    <group delimiter=", ">
-                        <text macro="author-en" />
-                        <text macro="title-short-en" />
-                        <text macro="locator-en" />
-                    </group>
+                <group delimiter=", ">
+                    <text macro="author-en" />
+                    <text macro="title-short-en" />
+                    <text macro="locator-en" />
                 </group>
             </else>
         </choose>
@@ -670,12 +668,10 @@
             </if>
             <else>
                 <!-- 再次引证时的项目简化 -->
-                <group delimiter="：">
-                    <group delimiter="，">
-                        <text macro="author-zh" />
-                        <text macro="title-short-zh" />
-                        <text macro="locator-zh" />
-                    </group>
+                <group delimiter="，">
+                    <text macro="author-zh" />
+                    <text macro="title-short-zh" />
+                    <text macro="locator-zh" />
                 </group>
             </else>
         </choose>
@@ -684,7 +680,7 @@
         <layout delimiter="；" suffix="。" locale="zh">
             <text macro="entry-layout-zh" />
         </layout>
-        <layout delimiter="; " suffix=". ">
+        <layout delimiter="; " suffix=".">
             <text macro="entry-layout-en" />
         </layout>
     </citation>

--- a/外交评论.csl
+++ b/外交评论.csl
@@ -6,8 +6,8 @@
         <title>外交评论</title>
         <id>http://www.zotero.org/styles/foreign-affairs-review</id>
         <link href="http://www.zotero.org/styles/foreign-affairs-review" rel="self" />
-        <link href="http://www.zotero.org/styles/social-sciences-in-china" rel="template" />
-        <link href="http://www.iwep.org.cn/cbw/cbw_xsqk/xsqk_sjjjyzz/xsqk_zsgf/" rel="documentation" />
+        <link href="http://www.zotero.org/styles/journal-of-world-economics-and-politics" rel="template" />
+        <link href="https://wjxy.cbpt.cnki.net/WKH/WebPublication/index.aspx" rel="documentation" />
         <author>
             <name>Edward Zhou</name>
             <email>edwardzhoujiaxi@gmail.com</email>
@@ -19,7 +19,7 @@
         <category citation-format="note" />
         <category field="political_science" />
         <category field="social_science" />
-        <updated>2023-06-21</updated>
+        <updated>2023-07-02T19:47:26+08:00</updated>
         <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under
             a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     </info>
@@ -263,9 +263,7 @@
     <macro name="container-periodical-zh">
         <group delimiter="，">
             <text variable="container-title" prefix="《" suffix="》" />
-            <group delimiter="，">
-                <text macro="date-zh" />
-            </group>
+            <text macro="date-zh" />
         </group>
         <text macro="issue-zh" />
     </macro>
@@ -293,19 +291,19 @@
         </choose>
     </macro>
     <macro name="container-newspaper-zh">
-    <group>
-      <text variable="container-title" prefix="《" suffix="》"/>
-      <text variable="publisher-place" prefix="（" suffix="）"/>
-      <group delimiter="，">
         <group>
-          <text macro="volume-zh"/>
-          <text macro="issue-zh"/>
+            <text variable="container-title" prefix="《" suffix="》"/>
+            <text variable="publisher-place" prefix="（" suffix="）"/>
+            <group delimiter="，">
+                <group>
+                    <text macro="volume-zh"/>
+                    <text macro="issue-zh"/>
+                </group>
+                <text macro="date-zh"/>
+                <text variable="section"/>
+            </group>
         </group>
-        <text macro="date-zh"/>
-        <text variable="section"/>
-      </group>
-    </group>
-  </macro>
+    </macro>
     <macro name="publisher-en">
         <choose>
             <if type="report">
@@ -568,85 +566,81 @@
             <text macro="locator-or-page-en" />
         </group>
     </macro>
-  <macro name="source-zh">
-    <group delimiter="：">
-      <group delimiter="，">
-        <text macro="author-zh"/>
-      </group>
-      <group delimiter="，">
-        <text macro="title-zh"/>
-        <choose>
-          <if type="article-journal article-magazine" match="any">
-            <text macro="container-periodical-zh"/>
-          </if>
-          <else-if type="chapter" match="any">
-            <text macro="container-booklike-zh"/>
-            <text macro="secondary-contributors-zh"/>
-            <text macro="publisher-zh"/>
-            <text macro="date-zh"/>
-          </else-if>
-          <else-if type="article-newspaper">
-            <text macro="container-newspaper-zh"/>
-          </else-if>
-          <else-if type="thesis">
+    <macro name="source-zh">
+        <group delimiter="：">
+            <text macro="author-zh"/>
             <group delimiter="，">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre"/>
-                </if>
-                <else>
-                  <text value="博士学位论文"/>
-                </else>
-              </choose>
-              <text macro="publisher-zh"/>
-              <text macro="date-zh"/>
+                <text macro="title-zh"/>
+                <choose>
+                    <if type="article-journal article-magazine" match="any">
+                        <text macro="container-periodical-zh"/>
+                    </if>
+                    <else-if type="chapter" match="any">
+                        <text macro="container-booklike-zh"/>
+                        <text macro="secondary-contributors-zh"/>
+                        <text macro="publisher-zh"/>
+                        <text macro="date-zh"/>
+                    </else-if>
+                    <else-if type="article-newspaper">
+                        <text macro="container-newspaper-zh"/>
+                    </else-if>
+                    <else-if type="thesis">
+                        <group delimiter="，">
+                            <choose>
+                                <if variable="genre">
+                                    <text variable="genre"/>
+                                </if>
+                                <else>
+                                    <text value="博士学位论文"/>
+                                </else>
+                            </choose>
+                            <text macro="publisher-zh"/>
+                            <text macro="date-zh"/>
+                        </group>
+                    </else-if>
+                    <else-if type="paper-conference">
+                        <choose>
+                            <if variable="container-title">
+                                <text macro="container-booklike-zh"/>
+                                <text macro="publisher-zh"/>
+                                <text macro="date-zh"/>
+                            </if>
+                            <else>
+                                <text macro="event-zh"/>
+                            </else>
+                        </choose>
+                    </else-if>
+                    <else-if type="collection manuscript personal_communication" match="any">
+                        <text macro="date-zh"/>
+                        <text macro="archive-zh"/>
+                    </else-if>
+                    <else-if type="post post-weblog software webpage" match="any">
+                        <text variable="container-title"/>
+                        <text macro="date-zh"/>
+                    </else-if>
+                    <else>
+                        <group delimiter="，">
+                            <text macro="secondary-contributors-zh"/>
+                            <text macro="publisher-zh"/>
+                            <text macro="date-zh"/>
+                        </group>
+                    </else>
+                </choose>
+                <text macro="access-zh"/>
+                <text macro="locator-or-page-zh"/>
             </group>
-          </else-if>
-          <else-if type="paper-conference">
-            <choose>
-              <if variable="container-title">
-                <text macro="container-booklike-zh"/>
-                <text macro="publisher-zh"/>
-                <text macro="date-zh"/>
-              </if>
-              <else>
-                <text macro="event-zh"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if type="collection manuscript personal_communication" match="any">
-            <text macro="date-zh"/>
-            <text macro="archive-zh"/>
-          </else-if>
-          <else-if type="post post-weblog software webpage" match="any">
-            <text variable="container-title"/>
-            <text macro="date-zh"/>
-          </else-if>
-          <else>
-            <group delimiter="，">
-              <text macro="secondary-contributors-zh"/>
-              <text macro="publisher-zh"/>
-              <text macro="date-zh"/>
-            </group>
-          </else>
-        </choose>
-        <text macro="access-zh"/>
-        <text macro="locator-or-page-zh"/>
-      </group>
-    </group>
-  </macro>
+        </group>
+    </macro>
     <macro name="entry-layout-en">
         <choose>
             <if position="first">
                 <text macro="source-en" />
             </if>
             <else>
-                <group delimiter="：">
-                    <group delimiter=", ">
-                        <text macro="author-en" />
-                        <text macro="title-short-en" />
-                        <text macro="locator-en" />
-                    </group>
+                <group delimiter=", ">
+                    <text macro="author-en" />
+                    <text macro="title-short-en" />
+                    <text macro="locator-en" />
                 </group>
             </else>
         </choose>
@@ -658,12 +652,10 @@
             </if>
             <else>
                 <!-- 再次引证时的项目简化 -->
-                <group delimiter="：">
-                    <group delimiter="，">
-                        <text macro="author-zh" />
-                        <text macro="title-short-zh" />
-                        <text macro="locator-zh" />
-                    </group>
+                <group delimiter="，">
+                    <text macro="author-zh" />
+                    <text macro="title-short-zh" />
+                    <text macro="locator-zh" />
                 </group>
             </else>
         </choose>
@@ -672,7 +664,7 @@
         <layout delimiter="；" suffix="。" locale="zh">
             <text macro="entry-layout-zh" />
         </layout>
-        <layout delimiter="; " suffix=". ">
+        <layout delimiter="; " suffix=".">
             <text macro="entry-layout-en" />
         </layout>
     </citation>


### PR DESCRIPTION
1. 世政经 `event-en` 的中文逗号修正为西文逗号。
2. 去掉了几个冗余的 `<group>` 结构。
3. 统一代码的缩进。
4. 《国际政治研究》官网 <https://www.jis.pku.edu.cn/index.htm> 给出的英文名称为“The Journal of International Studies”，所以 id 从“the-journal-of-international-politics”改为“the-journal-of-international-studies”。